### PR TITLE
Fixed enum variance

### DIFF
--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -527,7 +527,7 @@ class Value
      *
      * @param string $className
      *
-     * @return Enum
+     * @return mixed|Enum
      * @throws Exception\AssertionFailed If this value is not a string, or it is not any of the Enum names from
      *                                   $className.
      * @throws Exception\Runtime         If $className does not exist, or does not extend Enum.
@@ -596,7 +596,7 @@ class Value
      *
      * @param string $className
      *
-     * @return null|Enum
+     * @return null|mixed|Enum
      * @throws Exception\AssertionFailed If this value is not a string, nor null, or it is not any of the Enum names
      *                                   from $className.
      * @throws Exception\Runtime         If $className does not exist, or does not extend Enum.


### PR DESCRIPTION
Given
```
$foo = $json->enum(Foo::class);
```
`$foo` is inferred as `Enum`, not `Foo`, and does not typecheck when passed to a function expecting `Foo`.