### PR TITLE
Default date format should not have a time component

### DIFF
--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -519,7 +519,7 @@ class Value
      * @return DateTimeImmutable
      * @throws Exception\AssertionFailed If this value is not a string, or does not conform to the given format.
      */
-    public function date(string $format = 'Y-m-d'): DateTimeImmutable
+    public function date(string $format = 'Y-m-d|'): DateTimeImmutable
     {
         return $this->dateTime($format);
     }
@@ -533,7 +533,7 @@ class Value
      * @throws Exception\AssertionFailed If this value is not a string, nor null, or does not conform to the given
      *                                   format.
      */
-    public function ¿date(string $format = 'Y-m-d'): ?DateTimeImmutable
+    public function ¿date(string $format = 'Y-m-d|'): ?DateTimeImmutable
     {
         return $this->¿dateTime($format);
     }

--- a/tests/Json/ValueSpec.php
+++ b/tests/Json/ValueSpec.php
@@ -557,6 +557,19 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
+     * @throws Exception\AssertionFailed
+     */
+    public function it_should_provide_a_date_with_no_time_component()
+    {
+        $json   = "2018-01-01";
+
+        $this->beConstructedWith($json, '$');
+
+        $this->date()->format('Y-m-d\TH:i:s')->shouldBe('2018-01-01T00:00:00');
+    }
+
+    /**
+     * @test
      */
     public function it_should_failed_accessing_a_date_if_accessing_a_non_date()
     {


### PR DESCRIPTION
Set time to 0 when creating a date with default format.

Minor version?

```
$ php vendor/bin/phpspec run
```