### PR TITLE
Apply does not throw an AssertionFailed exception

### DIFF
--- a/src/Json/OptionalValue.php
+++ b/src/Json/OptionalValue.php
@@ -422,7 +422,6 @@ class OptionalValue
         return $this->value === null;
     }
 
-    /** @noinspection PhpDocRedundantThrowsInspection */
     /**
      * Apply a function to this value if it is not null, otherwise return null.
      *
@@ -437,7 +436,11 @@ class OptionalValue
      */
     public function ¿apply(callable $f)
     {
-        return $this->isNull() ? null : $f($this->value);
+        try {
+            return $this->isNull() ? null : $f($this->value);
+        } /** @noinspection PhpRedundantCatchClauseInspection */ catch (Exception\AssertionFailed $e) {
+            throw $e;
+        }
     }
 
     /**

--- a/src/Json/OptionalValue.php
+++ b/src/Json/OptionalValue.php
@@ -422,6 +422,7 @@ class OptionalValue
         return $this->value === null;
     }
 
+    /** @noinspection PhpDocRedundantThrowsInspection */
     /**
      * Apply a function to this value if it is not null, otherwise return null.
      *
@@ -432,6 +433,7 @@ class OptionalValue
      * @param callable $f Value -> a
      *
      * @return null|mixed a or null
+     * @throws Exception\AssertionFailed Or any other exception thrown by $f.
      */
     public function ¿apply(callable $f)
     {

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -883,6 +883,7 @@ class Value
         return $this->value === null;
     }
 
+    /** @noinspection PhpDocRedundantThrowsInspection */
     /**
      * Apply a function to this value.
      *
@@ -893,12 +894,14 @@ class Value
      * @param callable $f Value -> a
      *
      * @return mixed a
+     * @throws Exception\AssertionFailed Or any other exception thrown by $f.
      */
     public function apply(callable $f)
     {
         return $f($this);
     }
 
+    /** @noinspection PhpDocRedundantThrowsInspection */
     /**
      * Apply a function to this value if it is not null, otherwise return null.
      *
@@ -909,6 +912,7 @@ class Value
      * @param callable $f Value -> a
      *
      * @return null|mixed a or null
+     * @throws Exception\AssertionFailed Or any other exception thrown by $f.
      */
     public function ¿apply(callable $f)
     {

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -883,7 +883,6 @@ class Value
         return $this->value === null;
     }
 
-    /** @noinspection PhpDocRedundantThrowsInspection */
     /**
      * Apply a function to this value.
      *
@@ -898,10 +897,13 @@ class Value
      */
     public function apply(callable $f)
     {
-        return $f($this);
+        try {
+            return $f($this);
+        } /** @noinspection PhpRedundantCatchClauseInspection */ catch (Exception\AssertionFailed $e) {
+            throw $e;
+        }
     }
 
-    /** @noinspection PhpDocRedundantThrowsInspection */
     /**
      * Apply a function to this value if it is not null, otherwise return null.
      *
@@ -916,7 +918,11 @@ class Value
      */
     public function ¿apply(callable $f)
     {
-        return $this->isNull() ? null : $f($this);
+        try {
+            return $this->isNull() ? null : $f($this);
+        } /** @noinspection PhpRedundantCatchClauseInspection */ catch (Exception\AssertionFailed $e) {
+            throw $e;
+        }
     }
 
     /**


### PR DESCRIPTION
When parsing a Json object by only using `apply()` or `¿apply()` catching `Json\Exception\AssertionFailed` is considered redundant since the static analyzer can't trace the thrown exception to the call site:

```
try {
    $parseBaz = function (Json\Value $json) {
        $foo = $json->field('foo')->string();
        $bar = $json->field('bar')->int();

        return new Baz($foo, $bar);
    };

    Json::parse($string)->¿apply($parseBaz);
} catch (Json\Exception\CantDecode | Json\Exception\AssertionFailed $e) {
    //                               ^ Not redundant
}
```

This is fixed by declaring `Json\Exception\AssertionFailed` always as thrown (just like `either()`).