### PR TITLE
Added JsonSerializable instances

### DIFF
--- a/src/Json/OptionalValue.php
+++ b/src/Json/OptionalValue.php
@@ -4,12 +4,13 @@ namespace Vcn\Pipette\Json;
 
 use DateTime;
 use DateTimeImmutable;
+use JsonSerializable;
 use Vcn\Lib\Enum;
 
 /**
  * A JSON value that is either not present or null.
  */
-class OptionalValue
+class OptionalValue implements JsonSerializable
 {
     /**
      * Absent, null or a non-null value
@@ -438,8 +439,10 @@ class OptionalValue
     {
         try {
             return $this->isNull() ? null : $f($this->value);
+            // @codeCoverageIgnoreStart
         } /** @noinspection PhpRedundantCatchClauseInspection */ catch (Exception\AssertionFailed $e) {
             throw $e;
+            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -536,5 +539,13 @@ class OptionalValue
     public function getPointer(): string
     {
         return $this->pointer;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
     }
 }

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -4,12 +4,13 @@ namespace Vcn\Pipette\Json;
 
 use DateTime;
 use DateTimeImmutable;
+use JsonSerializable;
 use stdClass;
 use Vcn\Lib\Enum;
 use Vcn\Pipette\Json;
 use Vcn\Pipette\Json\Exception;
 
-class Value
+class Value implements JsonSerializable
 {
     /**
      * A JSON value anywhere in some JSON structure.
@@ -899,8 +900,10 @@ class Value
     {
         try {
             return $f($this);
+            // @codeCoverageIgnoreStart
         } /** @noinspection PhpRedundantCatchClauseInspection */ catch (Exception\AssertionFailed $e) {
             throw $e;
+            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -920,8 +923,10 @@ class Value
     {
         try {
             return $this->isNull() ? null : $f($this);
+            // @codeCoverageIgnoreStart
         } /** @noinspection PhpRedundantCatchClauseInspection */ catch (Exception\AssertionFailed $e) {
             throw $e;
+            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -1059,5 +1064,13 @@ class Value
     public function getPointer(): string
     {
         return $this->pointer;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
     }
 }

--- a/tests/Json/OptionalValueSpec.php
+++ b/tests/Json/OptionalValueSpec.php
@@ -6,7 +6,9 @@ use DateTimeImmutable;
 use PhpSpec\ObjectBehavior;
 use tests\res\Vcn\Pipette\NonEmptyEnum;
 use Vcn\Pipette\Json\Exception;
+use Vcn\Pipette\Json\OptionalValue;
 use Vcn\Pipette\Json\Value;
+use Webmozart\Assert\Assert;
 
 class OptionalValueSpec extends ObjectBehavior
 {
@@ -622,5 +624,23 @@ class OptionalValueSpec extends ObjectBehavior
         $this->¿encode()->shouldBe(null);
         $this->prettyPrint()->shouldBe($pretty);
         $this->¿prettyPrint()->shouldBe(null);
+    }
+
+    public function it_should_json_serialize()
+    {
+        $json = (object)[
+            "1" => "a",
+            "2" => "b",
+            "3" => "c",
+        ];
+
+        Assert::same(json_encode(new OptionalValue(new Value($json, '$'), '$')), '{"1":"a","2":"b","3":"c"}');
+    }
+
+    public function it_should_json_serialize_a_null_value()
+    {
+        $json = null;
+
+        Assert::same(json_encode(new OptionalValue(null, '$')), 'null');
     }
 }

--- a/tests/Json/ValueSpec.php
+++ b/tests/Json/ValueSpec.php
@@ -8,6 +8,7 @@ use tests\res\Vcn\Pipette\EmptyEnum;
 use tests\res\Vcn\Pipette\NonEmptyEnum;
 use Vcn\Pipette\Json\Exception;
 use Vcn\Pipette\Json\Value;
+use Webmozart\Assert\Assert;
 
 class ValueSpec extends ObjectBehavior
 {
@@ -561,7 +562,7 @@ class ValueSpec extends ObjectBehavior
      */
     public function it_should_provide_a_date_with_no_time_component()
     {
-        $json   = "2018-01-01";
+        $json = "2018-01-01";
 
         $this->beConstructedWith($json, '$');
 
@@ -1171,5 +1172,16 @@ class ValueSpec extends ObjectBehavior
         $this->shouldThrow(Exception\Runtime::class)->during('encode', []);
 
         fclose($json);
+    }
+
+    public function it_should_json_serialize()
+    {
+        $json = (object)[
+            "1" => "a",
+            "2" => "b",
+            "3" => "c",
+        ];
+
+        Assert::same(json_encode(new Value($json, '$')), '{"1":"a","2":"b","3":"c"}');
     }
 }


### PR DESCRIPTION
For objects that represent JSON, such omission may be considered a small oversight.