### PR TITLE
JSON Schema support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,40 @@
 {
-    "name": "vcn/pipette",
-    "description": "Easily extract what you need out of JSON.",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Robert Versteegt",
-            "email": "rversteegt@vcn.nl"
-        }
-    ],
-
-    "require": {
-        "php": "^7.1",
-
-        "ext-json": "*"
-    },
-
-    "autoload": {
-        "psr-4": {
-            "Vcn\\Pipette\\": "src/"
-        }
-    },
-
-    "suggest": {
-      "vcn/enum": "To extract Vcn\\Lib\\Enum values."
-    },
-
-    "require-dev": {
-        "leanphp/phpspec-code-coverage": "^4.2",
-        "phpspec/phpspec": "^4.3",
-        "phpunit/phpunit": "^7.1",
-
-        "vcn/enum": "^1.0"
-    },
-
-    "autoload-dev": {
-        "classmap": ["tests/res/"]
+  "name": "vcn/pipette",
+  "description": "Easily extract what you need out of JSON.",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Robert Versteegt",
+      "email": "rversteegt@vcn.nl"
     }
+  ],
+
+  "require": {
+    "php": "^7.1",
+    "ext-json": "*"
+  },
+
+  "autoload": {
+    "psr-4": {
+      "Vcn\\Pipette\\": "src/"
+    }
+  },
+
+  "suggest": {
+    "vcn/enum": "To extract Vcn\\Lib\\Enum values.",
+    "justinrainbow/json-schema": "To validate against JSON Schemas."
+  },
+
+  "require-dev": {
+    "dragonrun1/phpspec-code-coverage": "^4.2.3",
+    "phpspec/phpspec": "^5.1.0",
+    "phpunit/phpunit": "^7.1",
+    "justinrainbow/json-schema": "^5.2",
+    "vcn/enum": "^1.0"
+  },
+
+  "autoload-dev": {
+    "classmap": ["tests/res/"]
+  }
 }

--- a/examples/Color.php
+++ b/examples/Color.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Vcn\Pipette\Examples;
+
+class Color
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $category;
+
+    /**
+     * @var null|string
+     */
+    private $type;
+
+    /**
+     * @var int[]
+     */
+    private $codeRgba;
+
+    /**
+     * @var string
+     */
+    private $codeHex;
+
+    /**
+     * @param string      $name
+     * @param string      $category
+     * @param null|string $type
+     * @param int[]       $codeRgba
+     * @param string      $codeHex
+     */
+    public function __construct(string $name, string $category, ?string $type, array $codeRgba, string $codeHex)
+    {
+        $this->name     = $name;
+        $this->category = $category;
+        $this->type     = $type;
+        $this->codeRgba = $codeRgba;
+        $this->codeHex  = $codeHex;
+    }
+}

--- a/examples/RequestParser.php
+++ b/examples/RequestParser.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Vcn\Pipette\Examples;
+
+use Vcn\Pipette\Json;
+use Vcn\Pipette\Json\Validators\JsonSchemaRepository;
+
+class RequestParser
+{
+    /**
+     * @var JsonSchemaRepository
+     */
+    private $schemas;
+
+    /**
+     * @param JsonSchemaRepository $schemas
+     */
+    public function __construct(JsonSchemaRepository $schemas)
+    {
+        $this->schemas = $schemas;
+    }
+
+    /**
+     * @param string $body
+     *
+     * @return Color[]
+     * @throws Json\Exception\AssertionFailed
+     * @throws Json\Exception\CantDecode
+     */
+    public function parseRequest(string $body)
+    {
+        try {
+            $parseInt = function (Json\Value $json) {
+                return $json->int();
+            };
+
+            $parseColor = function (Json\Value $json) use ($parseInt) {
+                $name     = $json->field('name')->string();
+                $category = $json->field('category')->string();
+                $type     = $json->¿field('type')->¿string();
+                $codeRgba = $json->field('code')->field('rgba')->arrayMap($parseInt);
+                $codeHex  = $json->field('code')->field('hex')->string();
+
+                return new Color($name, $category, $type, $codeRgba, $codeHex);
+            };
+
+            $json = $this->schemas->get('/colors.schema.json')->parse($body);
+
+            return $json->arrayMap($parseColor);
+
+        } catch (Json\Exception\CantDecode | Json\Exception\AssertionFailed $e) {
+            throw $e;
+        }
+    }
+}

--- a/examples/color.schema.json
+++ b/examples/color.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^(\\p{L}|\\p{P}|\\p{N}| ){1,255}$"
+    },
+    "category": {
+      "type": "string",
+      "enum": ["hue", "value"]
+    },
+    "code": {
+      "type": "object",
+      "properties": {
+        "rgba": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          }
+        },
+        "hex": {
+          "type": "string",
+          "pattern": "^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$"
+        }
+      }
+    }
+  }
+}

--- a/examples/colors.json
+++ b/examples/colors.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "black",
+    "category": "hue",
+    "type": "primary",
+    "code": {
+      "rgba": [255,255,255,1],
+      "hex": "#000"
+    }
+  },
+  {
+    "name": "white",
+    "category": "value",
+    "code": {
+      "rgba": [0,0,0,1],
+      "hex": "#FFF"
+    }
+  },
+  {
+    "name": "red",
+    "category": "hue",
+    "type": "primary",
+    "code": {
+      "rgba": [255,0,0,1],
+      "hex": "#FF0"
+    }
+  }
+]

--- a/examples/colors.php
+++ b/examples/colors.php
@@ -1,123 +1,26 @@
 <?php
 
+namespace Vcn\Pipette\Examples;
+
+use JsonSchema\Validator;
 use Vcn\Pipette\Json;
+use Vcn\Pipette\Json\Validators\JsonSchemaRepository;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-// In this example we expect some JSON to contain a "colors" array, each with a color inside. Each color has a "color",
-// "category", an optional "type", a "code" field containing "rgba" with an array of integers describing the rgba
-// encoding and "hex" describing the hex encoding.
-$input = <<<JSON
-{
-  "colors": [
-    {
-      "color": "black",
-      "category": "hue",
-      "type": "primary",
-      "code": {
-        "rgba": [255,255,255,1],
-        "hex": "#000"
-      }
-    },
-    {
-      "color": "white",
-      "category": "value",
-      "code": {
-        "rgba": [0,0,0,1],
-        "hex": "#FFF"
-      }
-    },
-    {
-      "color": "red",
-      "category": "hue",
-      "type": "primary",
-      "code": {
-        "rgba": [255,0,0,1],
-        "hex": "#FF0"
-      }
-    },
-    {
-      "color": "blue",
-      "category": "hue",
-      "type": "primary",
-      "code": {
-        "rgba": [0,0,255,1],
-        "hex": "#00F"
-      }
-    },
-    {
-      "color": "yellow",
-      "category": "hue",
-      "type": "primary",
-      "code": {
-        "rgba": [255,255,0,1],
-        "hex": "#FF0"
-      }
-    },
-    {
-      "color": "green",
-      "category": "hue",
-      "type": "secondary",
-      "code": {
-        "rgba": [0,255,0,1],
-        "hex": "#0F0"
-      }
-    }
-  ]
-}
-JSON;
+require __DIR__ . '/Color.php';
+require __DIR__ . '/RequestParser.php';
 
 try {
-    $json = Json::parse($input);
+    $validator     = new Validator();
+    $baseUri       = "file://" . __DIR__;
+    $schemas       = new JsonSchemaRepository($validator, $baseUri);
+    $requestParser = new RequestParser($schemas);
 
-    // A parser for integers.
-    $parseInt = function (Json\Value $json) {
-        return $json->int();
-    };
+    $json   = file_get_contents(__DIR__ . '/colors.json');
+    $colors = $requestParser->parseRequest($json);
 
-    // A parser for colors:
-    $parseColor = function (Json\Value $json) use ($parseInt) {
-        $color    = $json->field('color')->string();
-        $category = $json->field('category')->string();
-        $type     = $json->¿field('type')->¿string(); // Perform nullsafe navigation.
-        $codeRgba = $json->field('code')->field('rgba')->arrayMap($parseInt); // An array of integers.
-        $codeHex  = $json->field('code')->field('hex')->string();
+    print_r($colors);
 
-        // You may have some Color class with these fields instead.
-        return [
-            'name'     => $color,
-            'category' => $category,
-            'type'     => $type,
-            'codeRgba' => $codeRgba,
-            'codeHex'  => $codeHex,
-        ];
-    };
-
-    // Expect the JSON to represent an array of colors:
-    $colors = $json->field('colors')->arrayMap($parseColor);
-
-    print_r(['colors' => $colors]);
-
-
-    // An incorrect parser for colors. This expects the $.color field to be called $.name instead:
-    $parseColorIncorrectly = function (Json\Value $json) use ($parseInt) {
-        $name     = $json->field('name')->string(); // Oops!
-        $category = $json->field('category')->string();
-        $type     = $json->¿field('type')->¿string();
-        $codeRgba = $json->field('code')->field('rgba')->arrayMap($parseInt);
-        $codeHex  = $json->field('code')->field('hex')->string();
-
-        return [
-            'name'     => $name,
-            'category' => $category,
-            'type'     => $type,
-            'codeRgba' => $codeRgba,
-            'codeHex'  => $codeHex,
-        ];
-    };
-
-    // This throws a clean exception with a clear cause of error:
-    $colors = $json->field('colors')->arrayMap($parseColorIncorrectly);
 } catch (Json\Exception\CantDecode | Json\Exception\AssertionFailed $e) {
-    print_r($e->getMessage());
+    echo $e->getMessage() . "\n";
 }

--- a/examples/colors.schema.json
+++ b/examples/colors.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "type": "array",
+  "items": {
+    "$ref": "color.schema.json"
+  }
+}

--- a/examples/huttonsrazor.php
+++ b/examples/huttonsrazor.php
@@ -30,22 +30,22 @@ JSON;
 try {
     // This parser translates it to a string "(6 + (2 + 9))".
     $parseExpr = function (Json\Value $json) use (&$parseExpr) {
-        return $json->either(
-            function (Json\Value $value) use ($parseExpr) {
-                return sprintf(
-                    "(%s + %s)",
-                    $value->field('+')->field('a')->apply($parseExpr),
-                    $value->field('+')->field('b')->apply($parseExpr)
-                );
-            },
-            function (Json\Value $value) {
-                return (string)$value->field('val')->int();
-            }
-        );
+        $parseAdd = function (Json\Value $value) use ($parseExpr) {
+            return sprintf(
+                "(%s + %s)",
+                $value->field('+')->field('a')->apply($parseExpr),
+                $value->field('+')->field('b')->apply($parseExpr)
+            );
+        };
+
+        $parseVal = function (Json\Value $value) {
+            return (string)$value->field('val')->int();
+        };
+
+        return $json->either($parseAdd, $parseVal);
     };
 
-    $json = Json::parse($input);
-    $expr = $json->apply($parseExpr);
+    $expr = Json::parse($input)->apply($parseExpr);
 
     print_r($expr);
 } catch (Json\Exception\CantDecode | Json\Exception\AssertionFailed $e) {

--- a/phpspec-nocc.yml
+++ b/phpspec-nocc.yml
@@ -1,0 +1,7 @@
+suites:
+  default:
+    spec_prefix: tests
+    psr4_prefix: Vcn\Pipette
+    namespace: Vcn\Pipette
+
+formatter.name: pretty

--- a/src/Json/Validators/JsonSchema.php
+++ b/src/Json/Validators/JsonSchema.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Vcn\Pipette\Json\Validators;
+
+use Throwable;
+use Vcn\Pipette\Json;
+use Vcn\Pipette\Json\Exception;
+
+class JsonSchema implements Validator
+{
+    use ValidatorTrait;
+
+    /**
+     * @var \JsonSchema\Validator
+     */
+    private $validator;
+
+    /**
+     * @var string
+     */
+    private $ref;
+
+    /**
+     * @param \JsonSchema\Validator $validator
+     * @param string                $ref
+     *
+     * @internal
+     */
+    public function __construct(\JsonSchema\Validator $validator, string $ref)
+    {
+        $this->validator = $validator;
+        $this->ref       = $ref;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate(Json\Value $json): void
+    {
+        try {
+            $mixed = $json->mixed();
+
+            $this->validator->reset();
+            $this->validator->validate($mixed, (object)['$ref' => $this->ref]);
+
+        } catch (Throwable $e) {
+            throw new Exception\Runtime($e->getMessage(), 0, $e);
+        }
+
+        foreach ($this->validator->getErrors() as $error) {
+            throw new Exception\AssertionFailed(
+                sprintf(
+                    "JSON Schema violation at $%s : %s.",
+                    $error['property'] !== '' ? sprintf(".%s", $error['property']) : '',
+                    $error['message']
+                )
+            );
+        }
+    }
+
+    /**
+     * @return \JsonSchema\Validator
+     */
+    public function getValidator(): \JsonSchema\Validator
+    {
+        return $this->validator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRef(): string
+    {
+        return $this->ref;
+    }
+}

--- a/src/Json/Validators/JsonSchemaRepository.php
+++ b/src/Json/Validators/JsonSchemaRepository.php
@@ -17,7 +17,7 @@ class JsonSchemaRepository
     /**
      * @param \JsonSchema\Validator $validator A validator that schemas will use when performing validation.
      * @param string                $baseUri   A base URI to use. E.g. file:///foo/bar will yield a schema reference to
-     *                                         file:///foo/bar/qux.schema.json if get("qux.schema.json") is called.
+     *                                         file:///foo/bar/qux.schema.json if get("/qux.schema.json") is called.
      */
     public function __construct(\JsonSchema\Validator $validator, string $baseUri)
     {

--- a/src/Json/Validators/JsonSchemaRepository.php
+++ b/src/Json/Validators/JsonSchemaRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Vcn\Pipette\Json\Validators;
+
+class JsonSchemaRepository
+{
+    /**
+     * @var \JsonSchema\Validator
+     */
+    private $validator;
+
+    /**
+     * @var string
+     */
+    private $baseUri;
+
+    /**
+     * @param \JsonSchema\Validator $validator A validator that schemas will use when performing validation.
+     * @param string                $baseUri   A base URI to use. E.g. file:///foo/bar will yield a schema reference to
+     *                                         file:///foo/bar/qux.schema.json if get("qux.schema.json") is called.
+     */
+    public function __construct(\JsonSchema\Validator $validator, string $baseUri)
+    {
+        $this->validator = $validator;
+        $this->baseUri   = $baseUri;
+    }
+
+    /**
+     * Obtain a schema referenced relative to the base URI.
+     *
+     * @param string $slug
+     *
+     * @return JsonSchema
+     */
+    public function get(string $slug): JsonSchema
+    {
+        return new JsonSchema($this->validator, sprintf("%s%s", $this->baseUri, $slug));
+    }
+}

--- a/src/Json/Validators/Validator.php
+++ b/src/Json/Validators/Validator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Vcn\Pipette\Json\Validators;
+
+use Vcn\Pipette\Json;
+use Vcn\Pipette\Json\Exception;
+
+/**
+ * Classes that can further validate JSON beyond its syntax.
+ *
+ * @see ValidatorTrait Use this trait to derive parse() from validate().
+ */
+interface Validator
+{
+    /**
+     * Validate a JSON value, throwing an AssertionFailed exception if the JSON is not valid.
+     *
+     * @param Json\Value $json
+     *
+     * @throws Exception\AssertionFailed If the JSON is not valid according to this validator.
+     */
+    public function validate(Json\Value $json): void;
+
+    /**
+     * Parse a JSON value, then validate it, throwing an AssertionFailed exception if the JSON is not valid.
+     *
+     * @param string $source  The JSON string.
+     * @param int    $depth   Maximum recursion depth.
+     * @param int    $options Pass <b>JSON_BIGINT_AS_STRING</b> to convert big ints to strings instead of floats.
+     *
+     * @return Json\Value
+     * @throws Exception\AssertionFailed If $source is syntactically valid JSON, but not valid according to this
+     *                                   validator.
+     * @throws Exception\CantDecode      If $source is not syntactically valid JSON, or if it can't be decoded for any
+     *                                   other reason. See json_last_error() for more information.
+     */
+    public function parse(string $source, int $depth = 512, int $options = 0): Json\Value;
+}

--- a/src/Json/Validators/ValidatorTrait.php
+++ b/src/Json/Validators/ValidatorTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vcn\Pipette\Json\Validators;
+
+use Vcn\Pipette\Json;
+use Vcn\Pipette\Json\Exception;
+
+/**
+ * Automatically derive parse() from validate().
+ */
+trait ValidatorTrait
+{
+    /**
+     * Validate a JSON value, throwing an AssertionFailed exception if the JSON is not valid.
+     *
+     * @param Json\Value $json
+     *
+     * @throws Exception\AssertionFailed If the value is not valid according to this validator.
+     */
+    public abstract function validate(Json\Value $json): void;
+
+    /**
+     * Parse a JSON value, then validate it, throwing an AssertionFailed exception if the JSON is not valid.
+     *
+     * @param string $source  The JSON string.
+     * @param int    $depth   Maximum recursion depth.
+     * @param int    $options Pass <b>JSON_BIGINT_AS_STRING</b> to convert big ints to strings instead of floats.
+     *
+     * @return Json\Value
+     * @throws Exception\AssertionFailed If $source is syntactically valid JSON, but not valid according to this
+     *                                   validator.
+     * @throws Exception\CantDecode      If $source is not syntactically valid JSON, or if it can't be decoded for any
+     *                                   other reason. See json_last_error() for more information.
+     */
+    public function parse(string $source, int $depth = 512, int $options = 0): Json\Value
+    {
+        $json = Json::parse($source, $depth, $options);
+
+        $this->validate($json);
+
+        return $json;
+    }
+}

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -9,6 +9,7 @@ use stdClass;
 use Vcn\Lib\Enum;
 use Vcn\Pipette\Json;
 use Vcn\Pipette\Json\Exception;
+use Vcn\Pipette\Json\Validators\Validator;
 
 class Value implements JsonSerializable
 {
@@ -1054,6 +1055,31 @@ class Value implements JsonSerializable
     public function ¿prettyPrint(int $depth = 512): ?string
     {
         return $this->isNull() ? null : $this->prettyPrint($depth);
+    }
+
+    /**
+     * Retrieve the underlying value, whatever it may be.
+     *
+     * @return mixed
+     */
+    public function mixed()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Run the given validator on this value, then return this value.
+     *
+     * @param Validator $validator
+     *
+     * @return Value
+     * @throws Exception\AssertionFailed If this value is not valid according to the given validator.
+     */
+    public function validate(Validator $validator): Value
+    {
+        $validator->validate($this);
+
+        return $this;
     }
 
     /**

--- a/tests/Json/OptionalValueSpec.php
+++ b/tests/Json/OptionalValueSpec.php
@@ -480,9 +480,6 @@ class OptionalValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_null_on_non_null()
     {
@@ -497,9 +494,7 @@ class OptionalValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
+     * @throws Exception\AssertionFailed
      */
     public function it_should_apply_functions_to_a_non_null_optional_value()
     {
@@ -516,9 +511,7 @@ class OptionalValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
+     * @throws Exception\AssertionFailed
      */
     public function it_should_return_null_applying_to_a_null_optional_value()
     {

--- a/tests/Json/Validators/JsonSchemaRepositorySpec.php
+++ b/tests/Json/Validators/JsonSchemaRepositorySpec.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace tests\Vcn\Pipette\Json\Validators;
+
+use Exception;
+use JsonSchema\Validator;
+use PhpSpec\ObjectBehavior;
+use Vcn\Pipette\Json;
+
+class JsonSchemaRepositorySpec extends ObjectBehavior
+{
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function it_should_get(Validator $validator, Json\Value $json)
+    {
+        $baseUri = "file:///foo";
+        $slug    = "/bar.schema.json";
+        $ref     = "file:///foo/bar.schema.json";
+
+        $this->beConstructedWith($validator, $baseUri);
+
+        $schema = $this->get($slug);
+
+        $schema->callOnWrappedObject('getValidator')->shouldBe($validator);
+        $schema->callOnWrappedObject('getRef')->shouldBe($ref);
+    }
+}

--- a/tests/Json/Validators/JsonSchemaSpec.php
+++ b/tests/Json/Validators/JsonSchemaSpec.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace tests\Vcn\Pipette\Json\Validators;
+
+use JsonSchema\Validator;
+use PhpSpec\ObjectBehavior;
+use RuntimeException;
+use Vcn\Pipette\Json;
+use Vcn\Pipette\Json\Exception;
+
+class JsonSchemaSpec extends ObjectBehavior
+{
+    /**
+     * @test
+     * @throws Exception\AssertionFailed
+     */
+    public function it_should_succesfully_validate(Validator $validator, Json\Value $json)
+    {
+        $ref   = "file:///foo/bar.schema.json";
+        $mixed = true;
+
+        $this->beConstructedWith($validator, $ref);
+
+        $json->mixed()->willReturn($mixed);
+
+        $validator->reset()->shouldBeCalled();
+        $validator->validate($mixed, (object)['$ref' => $ref])->shouldBeCalled();
+        $validator->getErrors()->willReturn([]);
+
+        $this->validate($json);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_fail_to_validate(Validator $validator, Json\Value $json)
+    {
+        $ref   = "file:///foo/bar.schema.json";
+        $mixed = true;
+        $error = ['property' => '', 'message' => 'Expected an object, true given'];
+        $e     = new Exception\AssertionFailed("JSON Schema violation at $ : Expected an object, true given.");
+
+        $this->beConstructedWith($validator, $ref);
+
+        $json->mixed()->willReturn($mixed);
+
+        $validator->reset()->shouldBeCalled();
+        $validator->validate($mixed, (object)['$ref' => $ref])->shouldBeCalled();
+        $validator->getErrors()->willReturn([$error]);
+
+        $this->shouldThrow($e)->during('validate', [$json]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_gracefully_go_pants_up(Validator $validator, Json\Value $json)
+    {
+        $ref   = "file:///foo/bar";
+        $mixed = true;
+        $e     = new RuntimeException("Failed to reticulate splines.");
+        $e2    = new Exception\Runtime("Failed to reticulate splines.", 0, $e);
+
+        $this->beConstructedWith($validator, $ref);
+
+        $json->mixed()->willReturn($mixed);
+
+        $validator->reset()->shouldBeCalled();
+        $validator->validate($mixed, (object)['$ref' => $ref])->willThrow($e)->shouldBeCalled();
+
+        $this->shouldThrow($e2)->during('validate', [$json]);
+    }
+
+    /**
+     * @test
+     * @throws Exception\AssertionFailed
+     * @throws Exception\CantDecode
+     */
+    public function it_should_validate_after_parsing(Validator $validator, Json\Value $json)
+    {
+        $ref   = "file:///foo/bar.schema.json";
+        $json  = 'true';
+        $mixed = true;
+
+        $this->beConstructedWith($validator, $ref);
+
+        $validator->reset()->shouldBeCalled();
+        $validator->validate($mixed, (object)['$ref' => $ref])->shouldBeCalled();
+        $validator->getErrors()->willReturn([]);
+
+        $this->parse($json);
+    }
+}

--- a/tests/Json/ValueSpec.php
+++ b/tests/Json/ValueSpec.php
@@ -7,6 +7,7 @@ use PhpSpec\ObjectBehavior;
 use tests\res\Vcn\Pipette\EmptyEnum;
 use tests\res\Vcn\Pipette\NonEmptyEnum;
 use Vcn\Pipette\Json\Exception;
+use Vcn\Pipette\Json\Validators\Validator;
 use Vcn\Pipette\Json\Value;
 use Webmozart\Assert\Assert;
 
@@ -31,9 +32,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_a_field_on_a_non_object()
     {
@@ -84,9 +82,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_an_array_item_on_a_non_array()
     {
@@ -151,9 +146,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_not_array_map_over_non_arrays()
     {
@@ -171,9 +163,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_rethrow_exceptions_when_array_mapping()
     {
@@ -259,9 +248,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_not_object_map_over_non_objects()
     {
@@ -280,9 +266,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_rethrow_exceptions_when_object_mapping()
     {
@@ -376,9 +359,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_an_int_on_a_non_number()
     {
@@ -445,9 +425,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_an_float_on_a_non_number()
     {
@@ -501,9 +478,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_a_string_on_a_non_string()
     {
@@ -788,9 +762,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_a_bool_on_a_non_bool()
     {
@@ -844,9 +815,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_true_on_false()
     {
@@ -900,9 +868,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_false_on_true()
     {
@@ -956,9 +921,6 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
      */
     public function it_should_fail_accessing_null_on_non_null()
     {
@@ -973,9 +935,7 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
+     * @throws Exception\AssertionFailed
      */
     public function it_should_apply_functions()
     {
@@ -992,9 +952,7 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
+     * @throws Exception\AssertionFailed
      */
     public function it_should_apply_functions_to_a_non_null_optional_value()
     {
@@ -1011,9 +969,7 @@ class ValueSpec extends ObjectBehavior
 
     /**
      * @test
-     * @throws \PhpSpec\Exception\Fracture\ClassNotFoundException
-     * @throws \PhpSpec\Exception\Fracture\FactoryDoesNotReturnObjectException
-     * @throws \ReflectionException
+     * @throws Exception\AssertionFailed
      */
     public function it_should_return_null_applying_to_a_null_optional_value()
     {
@@ -1174,6 +1130,9 @@ class ValueSpec extends ObjectBehavior
         fclose($json);
     }
 
+    /**
+     * @test
+     */
     public function it_should_json_serialize()
     {
         $json = (object)[
@@ -1183,5 +1142,42 @@ class ValueSpec extends ObjectBehavior
         ];
 
         Assert::same(json_encode(new Value($json, '$')), '{"1":"a","2":"b","3":"c"}');
+    }
+
+    /**
+     * @test
+     *
+     * @param Validator $validator
+     *
+     * @throws Exception\AssertionFailed
+     */
+    public function it_should_validate(Validator $validator)
+    {
+        $json = null;
+
+        $this->beConstructedWith($json, '$');
+
+        $validator->validate($this)->shouldBeCalled();
+
+        $this->validate($validator)->shouldBe($this);
+    }
+
+    /**
+     * @test
+     *
+     * @param Validator $validator
+     *
+     * @throws Exception\AssertionFailed
+     */
+    public function it_should_fail_to_validate(Validator $validator)
+    {
+        $json = null;
+        $e    = new Exception\AssertionFailed("Expected $ to be an object, null given.");
+
+        $this->beConstructedWith($json, '$');
+
+        $validator->validate($this)->willThrow($e)->shouldBeCalled();
+
+        $this->shouldThrow($e)->during('validate', [$validator]);
     }
 }


### PR DESCRIPTION
In order to facilitate better validation, I'm introducing a generic interface that can easily be run on top of existing JSON parsing code. Implementations provide a way of telling whether a JSON value is valid, and users can invoke such validators like so:
```php
$source = ...
$validator = ...
$parser = function (Json\Value $json) {
    ...
}

// Both are equivalent
$object = Json::parse($source)->validate($validator)->apply($parser);
$object = $validator->parse($source)->apply($parser);
```

The initial provided implementation is a JSON Schema validator using [justinrainbow/json-schema](https://github.com/justinrainbow/json-schema). Besides the validator instance, I have also added a "schema repository" which yields schemas from identifiers. These schemas can then parse strings to JSON themselves, such that these repositories provide a nice fluent interface that barely adds anything to existing "raw" parsing code:

```php
// before
class RequestParser {
    public function parseThing(string $body)
    {
        $parser = function (Json\Value $json) {
            ...
        };

        return Json::parse($body)->apply($parser);
    }
}

// after
class RequestParser {
    /**
     * @var JsonSchemaRepository
     */
    private $schemas;

    public function parseThing(string $body)
    {
        $parser = function (Json\Value $json) {
            ...
        };

        return $this->schemas->get('/thing')->parse($body)->apply($parser);
    }
}
```

**Miscellaneous**

- Rewrote the examples and README to better illustrate idioms of use.
- Upgraded `phpspec` to 5.x.
