### PR TITLE
Mention all errors when a validating a JSON Schema

### DIFF
--- a/src/Json/Validators/JsonSchema.php
+++ b/src/Json/Validators/JsonSchema.php
@@ -47,12 +47,33 @@ class JsonSchema implements Validator
             throw new Exception\Runtime($e->getMessage(), 0, $e);
         }
 
+        $errors = [];
+
         foreach ($this->validator->getErrors() as $error) {
+            $errors[] = sprintf(
+                "$%s : %s",
+                $error['property'] !== '' ? sprintf(".%s", $error['property']) : '',
+                $error['message']
+            );
+        }
+
+        if (count($errors) === 1) {
+            throw new Exception\AssertionFailed(sprintf("JSON Schema violation at %s.", $errors[0]));
+        }
+
+        if (count($errors) > 1) {
             throw new Exception\AssertionFailed(
                 sprintf(
-                    "JSON Schema violation at $%s : %s.",
-                    $error['property'] !== '' ? sprintf(".%s", $error['property']) : '',
-                    $error['message']
+                    "JSON Schema violations:\n    %s",
+                    implode(
+                        "\n    ",
+                        array_map(
+                            function (string $string) {
+                                return $string . '.';
+                            },
+                            $errors
+                        )
+                    )
                 )
             );
         }

--- a/tests/Json/Validators/JsonSchemaSpec.php
+++ b/tests/Json/Validators/JsonSchemaSpec.php
@@ -54,6 +54,36 @@ class JsonSchemaSpec extends ObjectBehavior
     /**
      * @test
      */
+    public function it_should_collapse_multiple_errors(Validator $validator, Json\Value $json)
+    {
+        $ref    = "file:///foo/bar.schema.json";
+        $mixed  = true;
+        $errors = [
+            ['property' => '', 'message' => 'Expected an object, true given'],
+            ['property' => '', 'message' => 'Expected a string, true given'],
+            ['property' => '', 'message' => 'Expected a donkey, true given'],
+        ];
+        $e      = new Exception\AssertionFailed(
+            "JSON Schema violations:\n" .
+            "    $ : Expected an object, true given.\n" .
+            "    $ : Expected a string, true given.\n" .
+            "    $ : Expected a donkey, true given."
+        );
+
+        $this->beConstructedWith($validator, $ref);
+
+        $json->mixed()->willReturn($mixed);
+
+        $validator->reset()->shouldBeCalled();
+        $validator->validate($mixed, (object)['$ref' => $ref])->shouldBeCalled();
+        $validator->getErrors()->willReturn($errors);
+
+        $this->shouldThrow($e)->during('validate', [$json]);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_gracefully_go_pants_up(Validator $validator, Json\Value $json)
     {
         $ref   = "file:///foo/bar";


### PR DESCRIPTION
In the following example `$.foo` is allowed to be `null` or an object with a required property `bar` that must match a regex:

```json
{
  "foo": {
    "anyOf": [
      {
        "type": "null"
      },
      {
        "type": "object",
        "properties": {
          "bar": {
            "type": "string",
            "pattern": "^[a-zA-Z0-9]{1,5}$"
          }
        },
        "required": ["bar"]
      }
    ]
  }
}
```

```json
{
  "foo": {
    "bar": "123456"
  }
}
```
```
> $.foo : Object value found, but a null is required.
> $.foo.bar : Does not match the regex pattern ^[a-zA-Z0-9]{1,5}$.
> $.foo : Failed to match at least one schema.
```

Only the first error is insufficient to identify the cause of error.