### PR TITLE
PHP8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,4 +285,15 @@ Pipette's behaviour for any other type is undefined.
 
 ## Tests
 
-Powered by [phpspec](http://www.phpspec.net/en/stable/): `php vendor/bin/phpspec run`
+Powered by [phpspec](http://www.phpspec.net/en/stable/). phpspec is configured to gather code coverage information. This requires [xdebug](https://pecl.php.net/package/xdebug) or [pcov](https://pecl.php.net/package/pcov). You can also disable code coverage.
+
+```
+# default (using pcov)
+php vendor/bin/phpspec run
+
+# xdebug coverage
+XDEBUG_MODE=coverage php vendor/bin/phpspec run
+
+# no code coverage
+php vendor/bin/phpspec run -c phpspec-nocc.yml
+```

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
 
   "require": {
-    "php": "^7.1",
+    "php": "^7.4|^8.0",
     "ext-json": "*"
   },
 
@@ -23,17 +23,16 @@
 
   "suggest": {
     "vcn/enum": "To extract Vcn\\Lib\\Enum values.",
-    "justinrainbow/json-schema": "To validate against JSON Schemas."
+    "justinrainbow/json-schema": "To validate against JSON Schemas.",
+    "ext-pcov": "Supplies code coverage data for friends-of-phpspec/phpspec-code-coverage"
   },
 
   "require-dev": {
-    "ext-pcov": "*",
-
-    "friends-of-phpspec/phpspec-code-coverage": "^4.2.3",
-    "phpspec/phpspec": "^6.1.0",
-    "phpunit/phpunit": "^7.1",
+    "friends-of-phpspec/phpspec-code-coverage": "^6.0",
+    "phpspec/phpspec": "^7.0",
+    "phpunit/phpunit": "^9.5",
     "justinrainbow/json-schema": "^5.2",
-    "vcn/enum": "^1.0"
+    "vcn/enum": "dev-FUN-335-php8 as 1.4.0"
   },
 
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "phpspec/phpspec": "^7.0",
     "phpunit/phpunit": "^9.5",
     "justinrainbow/json-schema": "^5.2",
-    "vcn/enum": "dev-FUN-335-php8 as 1.4.0"
+    "vcn/enum": "^1.0"
   },
 
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
 
   "suggest": {
     "vcn/enum": "To extract Vcn\\Lib\\Enum values.",
-    "justinrainbow/json-schema": "To validate against JSON Schemas.",
-    "ext-pcov": "Supplies code coverage data for friends-of-phpspec/phpspec-code-coverage"
+    "justinrainbow/json-schema": "To validate against JSON Schemas."
   },
 
   "require-dev": {

--- a/src/Json.php
+++ b/src/Json.php
@@ -58,7 +58,6 @@ class Json
      */
     public static function pretend($value): Value
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         return new Value($value, '$');
     }
 


### PR DESCRIPTION
Depends on https://github.com/vcn/enum/pull/5/files.

Version requirement for PHP is now ^7.4|^8.0. Public API hasn't changed. PHPUnit and phpspec have been upgraded. Dev-dependency ext-pcov has been changed into a suggestion as Composer 2 treats dev-dependencies differently.