### PR TITLE
Support int to datetime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 
   "require-dev": {
     "friends-of-phpspec/phpspec-code-coverage": "^6.0",
-    "phpspec/phpspec": "dev-main",
+    "phpspec/phpspec": "^7.2",
     "phpunit/phpunit": "^9.5",
     "justinrainbow/json-schema": "^5.2",
     "vcn/enum": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
 
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^8.0",
     "ext-json": "*"
   },
 
@@ -28,7 +28,7 @@
 
   "require-dev": {
     "friends-of-phpspec/phpspec-code-coverage": "^6.0",
-    "phpspec/phpspec": "^7.0",
+    "phpspec/phpspec": "dev-main",
     "phpunit/phpunit": "^9.5",
     "justinrainbow/json-schema": "^5.2",
     "vcn/enum": "^1.0"

--- a/src/Json/OptionalValue.php
+++ b/src/Json/OptionalValue.php
@@ -570,10 +570,7 @@ class OptionalValue implements JsonSerializable
         return $this->pointer;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->value;
     }

--- a/src/Json/OptionalValue.php
+++ b/src/Json/OptionalValue.php
@@ -296,6 +296,22 @@ class OptionalValue implements JsonSerializable
     }
 
     /**
+     * Assert this value is a number or null, assert it conforms to the 'U' date time format, then return that
+     * date time, or return null.
+     *
+     * @return null|DateTimeImmutable
+     * @throws Exception\AssertionFailed If this value is not a number, nor null.
+     */
+    public function ¿timestamp(): ?DateTimeImmutable
+    {
+        if ($this->isNull()) {
+            return null;
+        }
+
+        return $this->value->timestamp();
+    }
+
+    /**
      * Assert this value is a string or null, assert it is any of the names of the given Enum, then return that Enum
      * instance, or return null.
      *

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -561,22 +561,22 @@ class Value implements JsonSerializable
     }
 
     /**
-     * Assert this value is a string or int, assert it conforms to a given date time format, then return that date time.
+     * Assert this value is a string, assert it conforms to a given date time format, then return that date time.
      *
      * @param string $format
      *
      * @return DateTimeImmutable
-     * @throws Exception\AssertionFailed If this value is not a string or int, or does not conform to the given format.
+     * @throws Exception\AssertionFailed If this value is not a string, or does not conform to the given format.
      */
     public function dateTime(string $format = DateTime::ATOM): DateTimeImmutable
     {
-        $string = $this->isNumber() ? (string)$this->int() : $this->string();
+        $string = $this->string();
         $result = DateTimeImmutable::createFromFormat($format, $string);
 
         if ($result === false) {
             throw new Exception\AssertionFailed(
                 sprintf(
-                    "Expected %s to be a date time string or int according to format %s, '%s' given.",
+                    "Expected %s to be a date time string according to format %s, '%s' given.",
                     $this->pointer,
                     $format,
                     $string
@@ -604,6 +604,49 @@ class Value implements JsonSerializable
         }
 
         return $this->dateTime($format);
+    }
+
+    /**
+     * Assert this value is a number, assert it conforms to the 'U' date time format, then return that date time.
+     * For timestamp strings, use dateTime('U').
+     *
+     * @return DateTimeImmutable
+     * @throws Exception\AssertionFailed If this value is not a number, or does not conform to the 'U' format.
+     */
+    public function timestamp(): DateTimeImmutable
+    {
+        $string = (string)$this->int();
+        $result = DateTimeImmutable::createFromFormat('U', $string);
+
+        if ($result === false) {
+            throw new Exception\AssertionFailed(
+                sprintf(
+                    "Expected %s to be a number according to date time format %s, '%s' given.",
+                    $this->pointer,
+                    'U',
+                    Json::prettyPrintType($this->value)
+                )
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Assert this value is a number or null, assert it conforms to the 'U' date time format, then return that
+     * date time, or return null.
+     *
+     * @return null|DateTimeImmutable
+     * @throws Exception\AssertionFailed If this value is not a number, nor null, or does not conform to the 'U'
+     *                                   format.
+     */
+    public function ¿timestamp(): ?DateTimeImmutable
+    {
+        if ($this->isNull()) {
+            return $this->value;
+        }
+
+        return $this->timestamp();
     }
 
     /**

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -1149,10 +1149,7 @@ class Value implements JsonSerializable
         return $this->pointer;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->value;
     }

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -607,38 +607,22 @@ class Value implements JsonSerializable
     }
 
     /**
-     * Assert this value is a number, assert it conforms to the 'U' date time format, then return that date time.
-     * For timestamp strings, use dateTime('U').
+     * Assert this value is a number, then return a date time measured in that many seconds since the Unix Epoch.
      *
      * @return DateTimeImmutable
-     * @throws Exception\AssertionFailed If this value is not a number, or does not conform to the 'U' format.
+     * @throws Exception\AssertionFailed If this value is not a number, or an invalid Unix Epoch.
      */
     public function timestamp(): DateTimeImmutable
     {
-        $string = (string)$this->int();
-        $result = DateTimeImmutable::createFromFormat('U', $string);
+        $int = $this->int();
 
-        if ($result === false) {
-            throw new Exception\AssertionFailed(
-                sprintf(
-                    "Expected %s to be a number according to date time format %s, '%s' given.",
-                    $this->pointer,
-                    'U',
-                    Json::prettyPrintType($this->value)
-                )
-            );
-        }
-
-        return $result;
+        return new DateTimeImmutable("@$int");
     }
 
-    /**
-     * Assert this value is a number or null, assert it conforms to the 'U' date time format, then return that
-     * date time, or return null.
+    /**Assert this value is a number, then return a date time measured in that many seconds since the Unix Epoch.
      *
      * @return null|DateTimeImmutable
-     * @throws Exception\AssertionFailed If this value is not a number, nor null, or does not conform to the 'U'
-     *                                   format.
+     * @throws Exception\AssertionFailed If this value is not a number, nor null, or an invalid Unix Epoch.
      */
     public function ¿timestamp(): ?DateTimeImmutable
     {

--- a/src/Json/Value.php
+++ b/src/Json/Value.php
@@ -561,22 +561,22 @@ class Value implements JsonSerializable
     }
 
     /**
-     * Assert this value is a string, assert it conforms to a given date time format, then return that date time.
+     * Assert this value is a string or int, assert it conforms to a given date time format, then return that date time.
      *
      * @param string $format
      *
      * @return DateTimeImmutable
-     * @throws Exception\AssertionFailed If this value is not a string, or does not conform to the given format.
+     * @throws Exception\AssertionFailed If this value is not a string or int, or does not conform to the given format.
      */
     public function dateTime(string $format = DateTime::ATOM): DateTimeImmutable
     {
-        $string = $this->string();
+        $string = $this->isNumber() ? (string)$this->int() : $this->string();
         $result = DateTimeImmutable::createFromFormat($format, $string);
 
         if ($result === false) {
             throw new Exception\AssertionFailed(
                 sprintf(
-                    "Expected %s to be a date time string according to format %s, '%s' given.",
+                    "Expected %s to be a date time string or int according to format %s, '%s' given.",
                     $this->pointer,
                     $format,
                     $string

--- a/tests/Json/OptionalValueSpec.php
+++ b/tests/Json/OptionalValueSpec.php
@@ -311,6 +311,32 @@ class OptionalValueSpec extends ObjectBehavior
      * @test
      * @throws Exception\AssertionFailed
      */
+    public function it_should_provide_a_date_if_accessing_a_non_null_optional_timestamp()
+    {
+        $json = 1;
+
+        $this->beConstructedWith(new Value($json, '$'), '$');
+
+        $this->¿timestamp()->shouldBeAnInstanceOf(DateTimeImmutable::class);
+    }
+
+    /**
+     * @test
+     * @throws Exception\AssertionFailed
+     */
+    public function it_should_provide_null_if_accessing_a_null_optional_timestamp()
+    {
+        $json = null;
+
+        $this->beConstructedWith(new Value($json, '$'), '$');
+
+        $this->¿timestamp()->shouldBe(null);
+    }
+
+    /**
+     * @test
+     * @throws Exception\AssertionFailed
+     */
     public function it_should_provide_a_date_if_accessing_a_non_null_optional_date()
     {
         $json   = "2018-01-01";

--- a/tests/Json/ValueSpec.php
+++ b/tests/Json/ValueSpec.php
@@ -520,6 +520,61 @@ class ValueSpec extends ObjectBehavior
      * @test
      * @throws Exception\AssertionFailed
      */
+    public function it_should_provide_a_date_if_accessing_a_int()
+    {
+        $json = 1;
+
+        $this->beConstructedWith($json, '$');
+
+        $this->timestamp()->shouldBeAnInstanceOf(DateTimeImmutable::class);
+        $this->timestamp()->format('Y-m-d\TH:i:s')->shouldBe('1970-01-01T00:00:01');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_fail_accessing_a_timestamp_on_a_non_int()
+    {
+        $json = null;
+
+        $this->beConstructedWith($json, '$');
+
+        $e = new Exception\AssertionFailed("Expected $ to be a number, null given.");
+
+        $this->shouldThrow($e)->during('timestamp', []);
+    }
+
+    /**
+     * @test
+     * @throws Exception\AssertionFailed
+     */
+    public function it_should_provide_a_date_if_accessing_a_non_null_optional_timestamp()
+    {
+        $json = 1;
+
+        $this->beConstructedWith($json, '$');
+
+        $this->¿timestamp()->shouldBeAnInstanceOf(DateTimeImmutable::class);
+        $this->¿timestamp()->format('Y-m-d\TH:i:s')->shouldBe('1970-01-01T00:00:01');
+    }
+
+    /**
+     * @test
+     * @throws Exception\AssertionFailed
+     */
+    public function it_should_provide_null_if_accessing_a_null_optional_timestamp()
+    {
+        $json = null;
+
+        $this->beConstructedWith($json, '$');
+
+        $this->¿timestamp()->shouldBe(null);
+    }
+
+    /**
+     * @test
+     * @throws Exception\AssertionFailed
+     */
     public function it_should_provide_a_date_if_accessing_a_date()
     {
         $json   = "2018-01-01";


### PR DESCRIPTION
Timestamp with int support.

Example
```
<?php

use Vcn\Pipette\Json;

$input = <<<JSON
{
  "time1": 123456
  "time2": "123476"
}
JSON;

try {
    $json = Json::parse($input);
    var_dump($json->field('time1')->timestamp());
    var_dump($json->field('time2')->dateTime('U'));
} catch (\Exception $e) {
    error_log($e);
}
```

Patch tag please.